### PR TITLE
Swap out old yum version of CMake for latest version

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -48,11 +48,16 @@ rm -f epel-release-6*.rpm
 
 # Development tools and libraries
 yum -y install bzip2 make git patch unzip bison yasm diffutils \
-    automake which file cmake28 \
+    automake which file \
     kernel-devel-`uname -r` \
     devtoolset-2-binutils devtoolset-2-gcc \
     devtoolset-2-gcc-c++ devtoolset-2-gcc-gfortran \
     ${PYTHON_COMPILE_DEPS}
+
+# Install more recent version of cmake
+curl -O https://cmake.org/files/v3.8/cmake-3.8.1-Linux-x86_64.sh
+/bin/sh cmake-3.8.1-Linux-x86_64.sh --prefix=/usr/local --skip-license
+rm cmake-3.8.1-Linux-x86_64.sh
 
 # Install newest autoconf
 build_autoconf $AUTOCONF_ROOT $AUTOCONF_HASH


### PR DESCRIPTION
This change works (the newer version of cmake gets installed) but there is a problem with the Docker image that prevents a new build. @vitaly-krugl - please advise - this issue is present even before this change. Error message:

```
$ docker build --rm -t quay.io/numenta/manylinux1_x86_64_centos6 -f docker/Dockerfile-x86_64 docker/
...
+ curl -O https://cmake.org/files/v3.8/cmake-3.8.1-Linux-x86_64.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 30.7M  100 30.7M    0     0  1330k      0  0:00:23  0:00:23 --:--:-- 2188k
+ /bin/sh cmake-3.8.1-Linux-x86_64.sh --prefix=/usr/local --skip-license
CMake Installer Version: 3.8.1, Copyright (c) Kitware
This is a self-extracting archive.
The archive will be extracted to: /usr/local

Using target directory: /usr/local
Extracting, please wait...

Unpacking finished successfully
+ rm cmake-3.8.1-Linux-x86_64.sh
+ cmake --version
cmake version 3.8.1

   37 # EPEL support
CMake suite maintained and supported by Kitware (kitware.com/cmake).
+ build_autoconf autoconf-2.69 954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
+ local autoconf_fname=autoconf-2.69
+ check_var autoconf-2.69
+ '[' -z autoconf-2.69 ']'
+ local autoconf_sha256=954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
+ check_var 954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
+ '[' -z 954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969 ']'
+ check_var http://ftp.gnu.org/gnu/autoconf
+ '[' -z http://ftp.gnu.org/gnu/autoconf ']'
+ curl -sLO http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
+ check_sha256sum autoconf-2.69.tar.gz 954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
+ local fname=autoconf-2.69.tar.gz
+ check_var autoconf-2.69.tar.gz
+ '[' -z autoconf-2.69.tar.gz ']'
+ local sha256=954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
+ check_var 954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
+ '[' -z 954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969 ']'
+ echo '954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969  autoconf-2.69.tar.gz'
+ sha256sum -c autoconf-2.69.tar.gz.sha256
autoconf-2.69.tar.gz: OK
+ rm autoconf-2.69.tar.gz.sha256
+ tar -zxf autoconf-2.69.tar.gz
+ cd autoconf-2.69
+ do_standard_install
+ ./configure
+ make
+ make install
+ rm -rf autoconf-2.69 autoconf-2.69.tar.gz
+ autoconf --version
autoconf (GNU Autoconf) 2.69
Copyright (C) 2012 Free Software Foundation, Inc.
License GPLv3+/Autoconf: GNU GPL version 3 or later
<http://gnu.org/licenses/gpl.html>, <http://gnu.org/licenses/exceptions.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by David J. MacKenzie and Akim Demaille.
+ build_openssl openssl-1.0.2h 1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919
+ local openssl_fname=openssl-1.0.2h
+ check_var openssl-1.0.2h
+ '[' -z openssl-1.0.2h ']'
+ local openssl_sha256=1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919
+ check_var 1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919
+ '[' -z 1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919 ']'
+ check_var ftp://ftp.openssl.org/source
+ '[' -z ftp://ftp.openssl.org/source ']'
+ curl -sLO ftp://ftp.openssl.org/source/openssl-1.0.2h.tar.gz
The command '/bin/sh -c bash build_scripts/build.sh && rm -r build_scripts' returned a non-zero code: 78
```